### PR TITLE
Lock down listed to posts

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -43,6 +43,7 @@
     <link rel="stylesheet" href="{{ `assets/syntax.css` | relURL }}">
     <link rel="stylesheet" href="{{ `assets/primer-build.css` | relURL }}">
     <link rel="stylesheet" href="{{ `assets/style.css` | relURL }}">
+    <link rel="stylesheet" href="{{ `assets/custom_style.css` | relURL }}">
   </head>
 
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -79,5 +79,6 @@
     <!-- MathJax -->
     <script type="text/x-mathjax-config">MathJax.Hub.Config({ tex2jax: { inlineMath: [['$','$'], ['\\(','\\)']] } });</script>
     {{ end }}
+    {{ partial "final_footer.html" . }}
   </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -39,10 +39,11 @@
     <meta name="twitter:image" content="{{ .Site.BaseURL }}twitter-card.png">
     {{ end }}
 
-
     <link rel="stylesheet" href="{{ `assets/syntax.css` | relURL }}">
     <link rel="stylesheet" href="{{ `assets/primer-build.css` | relURL }}">
     <link rel="stylesheet" href="{{ `assets/style.css` | relURL }}">
+
+    {{ partial "custom_head.html" . }}
     <link rel="stylesheet" href="{{ `assets/custom_style.css` | relURL }}">
   </head>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
   <h1>{{ .Title }}</h1>
   {{ .Content }}
 
-  {{ range .Paginator.Pages }}
+  {{ range where .Paginator.Pages "Section" "posts" }}
   <div>
     <div>
       <a href="{{ .RelPermalink }}">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,6 +17,7 @@
         <h3>{{ .Title }}</h3>
       </a>
     </div>
+    {{ .Summary }}
   </div>
   {{ end }}
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,10 +16,7 @@
       <a href="{{ .RelPermalink }}">
         <h3>{{ .Title }}</h3>
       </a>
-      <small>{{ .Permalink }}</small>
-      {{ .Date.Format "2006-01-02" }}
     </div>
-    {{ .Summary }}
   </div>
   {{ end }}
 

--- a/layouts/partials/card.page.html
+++ b/layouts/partials/card.page.html
@@ -1,21 +1,10 @@
 <!-- single page card -->
-<div class="rounded-2 box-shadow-medium px-3 pb-2 pt-2 mb-3">
+<div class="rounded-2">
   <div class="Subhead mb-2">
     <div class="Subhead-heading">
       <a href="{{ .RelPermalink }}">
-        <div class="h2 mt-1 mb-1">{{ .Title }}</div>
+        <div class="h3">{{ .Title }}</div>
       </a>
     </div>
-    <div class="Subhead-description">
-      {{ partial "taxonomy.html" . }}
-      <div class="float-md-right">
-        <span>{{ .Date.Format "2006-01-02" }}</span>
-      </div>
-    </div>
-  </div>
-  <div class="text-gray">
-    <!-- summary -->
-    {{ .Summary }}
-    <a class="muted-link" href="{{ .RelPermalink }}">…</a>
   </div>
 </div>

--- a/layouts/partials/card.page.html
+++ b/layouts/partials/card.page.html
@@ -6,6 +6,9 @@
         <div class="h2 mt-1 mb-1">{{ .Title }}</div>
       </a>
     </div>
+    <div class="Subhead-description">
+      {{ partial "taxonomy.html" . }}
+    </div>
   </div>
   <div class="text-gray">
     <!-- summary -->

--- a/layouts/partials/card.page.html
+++ b/layouts/partials/card.page.html
@@ -1,10 +1,15 @@
 <!-- single page card -->
-<div class="rounded-2">
+<div class="rounded-2 box-shadow-medium px-3 pb-2 pt-2 mb-3">
   <div class="Subhead mb-2">
     <div class="Subhead-heading">
       <a href="{{ .RelPermalink }}">
-        <div class="h3">{{ .Title }}</div>
+        <div class="h2 mt-1 mb-1">{{ .Title }}</div>
       </a>
     </div>
+  </div>
+  <div class="text-gray">
+    <!-- summary -->
+    {{ .Summary }}
+    <a class="muted-link" href="{{ .RelPermalink }}">…</a>
   </div>
 </div>

--- a/layouts/partials/custom_head.html
+++ b/layouts/partials/custom_head.html
@@ -1,0 +1,2 @@
+{{/* Custom HTML head tag contents go here. The purpose of this file is to allow
+  adding contents by the site using this template, so it should remain empty */}}

--- a/layouts/partials/final_footer.html
+++ b/layouts/partials/final_footer.html
@@ -1,0 +1,1 @@
+<!-- Footer filler section at the very bottom of the html body -->

--- a/static/assets/custom_style.css
+++ b/static/assets/custom_style.css
@@ -1,0 +1,1 @@
+/* This is a stand in stylesheet that allows people using this template to add their own custom styles. */


### PR DESCRIPTION
Previously this theme would display everything within content as if it were a new post to be listed. When I wanted to add a privacy policy it was also listing that and the same would be true for the terms and conditions or an about page which doesn't seem sensible.

This alters this behavior so that it only shows new posts.